### PR TITLE
Added support for setting ciphers on `requireTLS` for SMTP email

### DIFF
--- a/src/assets/storage/schemas/configuration/configuration-save.json
+++ b/src/assets/storage/schemas/configuration/configuration-save.json
@@ -114,15 +114,25 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["ocpp"]
+            "enum": [
+              "ocpp"
+            ]
           },
           "implementation": {
             "type": "string",
-            "enum": ["soap", "json"]
+            "enum": [
+              "soap",
+              "json"
+            ]
           },
           "protocol": {
             "type": "string",
-            "enum": ["http", "https", "ws", "wss"]
+            "enum": [
+              "http",
+              "https",
+              "ws",
+              "wss"
+            ]
           },
           "host": {
             "type": "string"
@@ -148,7 +158,10 @@
       "properties": {
         "protocol": {
           "type": "string",
-          "enum": ["http", "https"]
+          "enum": [
+            "http",
+            "https"
+          ]
         },
         "host": {
           "type": "string"
@@ -206,7 +219,10 @@
       "properties": {
         "protocol": {
           "type": "string",
-          "enum": ["http", "https"]
+          "enum": [
+            "http",
+            "https"
+          ]
         },
         "host": {
           "type": "string"
@@ -226,11 +242,16 @@
       "properties": {
         "implementation": {
           "type": "string",
-          "enum": ["prometheus"]
+          "enum": [
+            "prometheus"
+          ]
         },
         "protocol": {
           "type": "string",
-          "enum": ["http", "https"]
+          "enum": [
+            "http",
+            "https"
+          ]
         },
         "host": {
           "type": "string"
@@ -300,7 +321,9 @@
       "properties": {
         "implementation": {
           "type": "string",
-          "enum": ["mongodb"]
+          "enum": [
+            "mongodb"
+          ]
         },
         "uri": {
           "type": "string"
@@ -331,7 +354,10 @@
       "properties": {
         "protocol": {
           "type": "string",
-          "enum": ["http", "https"]
+          "enum": [
+            "http",
+            "https"
+          ]
         },
         "host": {
           "type": "string"
@@ -532,7 +558,22 @@
               "type": "boolean"
             },
             "requireTLS": {
-              "type": "boolean"
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "ciphers": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ciphers"
+                  ]
+                }
+              ]
             },
             "user": {
               "type": "string"
@@ -567,7 +608,22 @@
               "type": "boolean"
             },
             "requireTLS": {
-              "type": "boolean"
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "ciphers": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ciphers"
+                  ]
+                }
+              ]
             },
             "user": {
               "type": "string"

--- a/src/assets/storage/schemas/configuration/configuration-save.json
+++ b/src/assets/storage/schemas/configuration/configuration-save.json
@@ -114,25 +114,15 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "ocpp"
-            ]
+            "enum": ["ocpp"]
           },
           "implementation": {
             "type": "string",
-            "enum": [
-              "soap",
-              "json"
-            ]
+            "enum": ["soap", "json"]
           },
           "protocol": {
             "type": "string",
-            "enum": [
-              "http",
-              "https",
-              "ws",
-              "wss"
-            ]
+            "enum": ["http", "https", "ws", "wss"]
           },
           "host": {
             "type": "string"
@@ -158,10 +148,7 @@
       "properties": {
         "protocol": {
           "type": "string",
-          "enum": [
-            "http",
-            "https"
-          ]
+          "enum": ["http", "https"]
         },
         "host": {
           "type": "string"
@@ -219,10 +206,7 @@
       "properties": {
         "protocol": {
           "type": "string",
-          "enum": [
-            "http",
-            "https"
-          ]
+          "enum": ["http", "https"]
         },
         "host": {
           "type": "string"
@@ -242,16 +226,11 @@
       "properties": {
         "implementation": {
           "type": "string",
-          "enum": [
-            "prometheus"
-          ]
+          "enum": ["prometheus"]
         },
         "protocol": {
           "type": "string",
-          "enum": [
-            "http",
-            "https"
-          ]
+          "enum": ["http", "https"]
         },
         "host": {
           "type": "string"
@@ -321,9 +300,7 @@
       "properties": {
         "implementation": {
           "type": "string",
-          "enum": [
-            "mongodb"
-          ]
+          "enum": ["mongodb"]
         },
         "uri": {
           "type": "string"
@@ -354,10 +331,7 @@
       "properties": {
         "protocol": {
           "type": "string",
-          "enum": [
-            "http",
-            "https"
-          ]
+          "enum": ["http", "https"]
         },
         "host": {
           "type": "string"

--- a/src/types/configuration/EmailConfiguration.ts
+++ b/src/types/configuration/EmailConfiguration.ts
@@ -1,10 +1,12 @@
+import {SMTPSocketOptions} from "emailjs/smtp/connection";
+
 export default interface EmailConfiguration {
   smtp: {
     from: string;
     host: string;
     port: number;
-    secure: boolean;
-    requireTLS: boolean;
+    secure: boolean | SMTPSocketOptions;
+    requireTLS: boolean | SMTPSocketOptions;
     user: string;
     password: string;
   };


### PR DESCRIPTION
Added support for setting TLS cipther.  When using Office360 as an SMTP relay SSSv2 is not supported by Microsoft.


You can enable SSLv3 using:

```
"Email": {
    "smtp": {
      ...
      "requireTLS": { "ciphers": "SSLv3" },
      ...
    }
  }
```